### PR TITLE
Update navigation, content and footer widths to match designs

### DIFF
--- a/wp-content/themes/twentyseventeen-wp20/footer.php
+++ b/wp-content/themes/twentyseventeen-wp20/footer.php
@@ -1,4 +1,4 @@
-			<div class="wrap">
+			<div class="wrap wrap-wide">
 
 			<?php if ( has_nav_menu( 'social' ) && ( is_page('news') || is_single() ) ) :
 			?>
@@ -37,7 +37,7 @@
 
 
 		<footer id="colophon" class="site-footer">
-			<div class="wrap">
+			<div class="wrap wrap-wide">
 				<?php
 				get_template_part( 'template-parts/footer/footer', 'widgets' );
 

--- a/wp-content/themes/twentyseventeen-wp20/header.php
+++ b/wp-content/themes/twentyseventeen-wp20/header.php
@@ -22,7 +22,7 @@ use WP20\Locales;
 			<?php get_template_part( 'template-parts/header/header', 'image' ); ?>
 
 			<?php if ( has_nav_menu( 'top' ) ) : ?>
-				<div class="navigation-top">
+				<div class="navigation-top wrap wrap-wide">
 					<?php get_template_part( 'template-parts/header/navigation', 'top' ); ?>
 					<?php Locales\locale_switcher(); ?>
 				</div>

--- a/wp-content/themes/twentyseventeen-wp20/page-live.php
+++ b/wp-content/themes/twentyseventeen-wp20/page-live.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-<div class="wrap">
+<div class="wrap wrap-wide">
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main" role="main">
 			<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>

--- a/wp-content/themes/twentyseventeen-wp20/page-news.php
+++ b/wp-content/themes/twentyseventeen-wp20/page-news.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-	<div class="wrap wrap-unconstrained wp20-news">
+	<div class="wrap wp20-news">
 		<div id="secondary">
 			<h1 class="entry-title">
 				<?php

--- a/wp-content/themes/twentyseventeen-wp20/page-swag.php
+++ b/wp-content/themes/twentyseventeen-wp20/page-swag.php
@@ -4,7 +4,7 @@ use WP20\Theme;
 
 <?php get_header(); ?>
 
-	<div class="wrap wrap-unconstrained">
+	<div class="wrap wrap-wide">
 		<div id="primary" class="content-area">
 			<main id="main" class="site-main" role="main">
 				<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
@@ -14,9 +14,7 @@ use WP20\Theme;
 					</header>
 					
 					<div class="entry-content">
-						<p class="wrap wrap-constrained">
-							<?php esc_html_e( 'These 20th anniversary logos and files are available for download for folks who want to print their own swag:', 'wp20' ); ?>
-						</p>
+						<?php esc_html_e( 'These 20th anniversary logos and files are available for download for folks who want to print their own swag:', 'wp20' ); ?>
 
 						<ul class="entry-content-section downloads-wrapper">
 							<?php foreach ( Theme\get_swag_download_items() as $item ) : ?>
@@ -41,14 +39,12 @@ use WP20\Theme;
 							<?php endforeach; ?>
 						</ul>
 
-						<p class="wrap wrap-constrained">
-							<?php
-							printf(
-								wp_kses_post( __( 'Check out the <a href="%s">WordPress Swag Store</a> to get your hands on new, limited edition WP20 swag.', 'wp20' ) ),
-								'https://mercantile.wordpress.org/product-category/wordpress-20/'
-							);
-							?>
-						</p>
+						<?php
+						printf(
+							wp_kses_post( __( 'Check out the <a href="%s">WordPress Swag Store</a> to get your hands on new, limited edition WP20 swag.', 'wp20' ) ),
+							'https://mercantile.wordpress.org/product-category/wordpress-20/'
+						);
+						?>
 
 					</div>
 

--- a/wp-content/themes/twentyseventeen-wp20/page-whats-on.php
+++ b/wp-content/themes/twentyseventeen-wp20/page-whats-on.php
@@ -1,6 +1,6 @@
 <?php get_header(); ?>
 
-<div class="wrap">
+<div class="wrap wrap-wide">
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main" role="main">
 			<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>

--- a/wp-content/themes/twentyseventeen-wp20/single.php
+++ b/wp-content/themes/twentyseventeen-wp20/single.php
@@ -12,7 +12,7 @@
 
 get_header(); ?>
 
-<div class="wrap wrap-unconstrained">
+<div class="wrap">
 	<div id="primary" class="content-area">
 		<main id="main" class="site-main">
 

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -318,6 +318,12 @@ body.page .entry-header {
 	border-bottom: 1px solid var(--wp20--color--border);
 }
 
+@media screen and (max-width: 48em) {
+	.navigation-top {
+		padding: 0;
+	}
+}
+
 @media screen and (min-width: 48em) {
 	.navigation-top {
 		border-bottom: 0;
@@ -351,6 +357,14 @@ body.page .entry-header {
 
 .admin-bar .site-navigation-fixed.navigation-top {
 	top: auto;
+}
+
+.main-navigation > div > ul {
+	padding: 0;
+}
+
+.main-navigation li {
+	padding: 0 var(--wp20--spacing--xsmall);
 }
 
 .main-navigation.toggled-on .menu-top-menu-container {

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -34,11 +34,9 @@ Template:    twentyseventeen
 	--wp20--spacing--medium: 50px;
 	--wp20--spacing--large: 80px;
 	--wp20--spacing--edge-space: var(--wp20--spacing--xsmall);
-	--wp20--spacing--top-nav-left: calc(var(--wp20--spacing--edge-space) - 1.25em);
 
-	--wp20--screen-width-constrained: 760px;
-	--wp20--screen-width: 960px;
-	--wp20--screen-width-unconstrained: 1320px;
+	--wp20--screen-width: 940px;
+	--wp20--screen-width-wide: 1160px;
 
 	--wp20--column-width-left: 33.33%;
 }
@@ -134,6 +132,7 @@ body.page .entry-header {
 }
 
 .wrap {
+	box-sizing: content-box;
 	padding-left: var(--wp20--spacing--edge-space);
 	padding-right: var(--wp20--spacing--edge-space);
 	max-width: unset;
@@ -158,19 +157,11 @@ body.page .entry-header {
 	}
 
 	.wrap {
-		max-width: calc( var(--wp20--screen-width) + 2 * var(--wp20--spacing--edge-space) );
+		max-width: var(--wp20--screen-width);
 	}
 
-	.wrap.wrap-constrained {
-		max-width: calc( var(--wp20--screen-width-constrained) + 2 * var(--wp20--spacing--edge-space) );
-	}
-
-	.wrap .wrap.wrap-constrained {
-		max-width: var(--wp20--screen-width-constrained);
-	}
-
-	.wrap.wrap-unconstrained {
-		max-width: var(--wp20--screen-width-unconstrained);
+	.wrap.wrap-wide {
+		max-width: var(--wp20--screen-width-wide);
 	}
 
 	.site-content,
@@ -233,6 +224,10 @@ body.page .entry-header {
 /*
  * Header
  */
+
+.site-header {
+	background-color: white;
+}
 
 .custom-header {
 	grid-column: 1 / span 2;
@@ -301,24 +296,6 @@ body.page .entry-header {
  * Navigation
  */
 
-@media screen and ( min-width: 48em ) {
-	.navigation-top .wrap {
-		padding-left: var(--wp20--spacing--top-nav-left);
-	}
-}
-
-@media screen and (min-width: 67em) {
-	.navigation-top .wrap {
-		padding-left: var(--wp20--spacing--top-nav-left);
-	}
-}
-
-@media screen and (min-width: 67em) {
-	.navigation-top .wrap {
-		padding-left: var(--wp20--spacing--top-nav-left);
-	}
-}
-
 .site-navigation-fixed.navigation-top-container {
 	position: fixed;
 	top: 0;
@@ -333,7 +310,6 @@ body.page .entry-header {
 	top: 32px;
 }
 
-
 .navigation-top {
 	position: relative;
 	z-index: 20;
@@ -345,8 +321,11 @@ body.page .entry-header {
 @media screen and (min-width: 48em) {
 	.navigation-top {
 		border-bottom: 0;
-		padding-left: var(--wp20--spacing--edge-space);
-		padding-right: var(--wp20--spacing--edge-space);
+		width: unset;
+	}
+
+	.navigation-top nav {
+		margin-left: calc(var(--wp20--spacing--xxxsmall) * -1);
 	}
 }
 
@@ -629,7 +608,7 @@ body.page .entry-header {
 .navigation-top-menu-container .select2-container--default .select2-results__option--highlighted[aria-selected=false] {
 	background-color: transparent !important;
 	color: var(--wp20--color--text) !important;
-	padding: 12px var(--wp20--spacing--edge-space);
+	padding: 12px var(--wp20--spacing--xsmall);
 }
 
 .navigation-top-menu-container .select2-container--default .select2-results__option[aria-selected=true] {


### PR DESCRIPTION
Simplified layout overall with only wrap (940px) and wrap-wide (1160px) widths required.

A wrap is introduced into the top navigation to keep that width aligned with the outermost page and footer content.

## Screenshots

| News | News mobile | Swag | Swag mobile |
|-|-|-|-|
| ![localhost_8888_(Desktop)](https://user-images.githubusercontent.com/1017872/227835970-18145d49-56ac-4d19-bcc8-5536b5e53ce2.png) | ![localhost_8888_(Samsung Galaxy S20 Ultra) (3)](https://user-images.githubusercontent.com/1017872/227836211-af25ba02-38a0-42be-84ef-dd5d299631d9.png) | ![localhost_8888_swag_(Desktop) (2)](https://user-images.githubusercontent.com/1017872/227836005-3d1229e9-6c12-4365-acb8-90a23f1db321.png) | ![localhost_8888_swag_(Samsung Galaxy S20 Ultra) (1)](https://user-images.githubusercontent.com/1017872/227836127-05f57344-2aec-4c73-8669-32e789e750ff.png) |