### PR TITLE
Update the navigation and language switcher.

### DIFF
--- a/wp-content/mu-plugins/assets/locale-switcher.js
+++ b/wp-content/mu-plugins/assets/locale-switcher.js
@@ -30,7 +30,7 @@
 
 			// This has to stay `select2`; `selectWoo:open` will not work.
 			app.$switcher.on( 'select2:open', function() {
-				app.$container.find( 'input[type="search"]').attr('placeholder', app.$container.attr( 'data-placeholder' ) );
+				app.$container.find( 'input' ).attr( 'placeholder', app.$container.attr( 'data-placeholder' ) );
 
 				// Turn off the menu if it's open.
 				if( $( '#site-navigation' ).hasClass( 'toggled-on' ) ) {

--- a/wp-content/mu-plugins/assets/locale-switcher.js
+++ b/wp-content/mu-plugins/assets/locale-switcher.js
@@ -15,6 +15,7 @@
 			app.$switcher = $( '#wp20-locale-switcher' );
 			app.$notice   = $( '.wp20-locale-notice' );
 			app.$container = $( '.navigation-top-menu-container' );
+			app.$outerContainer = $( '.wp20-locale-switcher-container' );
 
 			app.$switcher.selectWoo( {
 				language: app.locale,
@@ -36,7 +37,13 @@
 				if( $( '#site-navigation' ).hasClass( 'toggled-on' ) ) {
 					$( '.menu-toggle' ).trigger( 'click' );
 				}
+
+				app.$outerContainer.addClass( 'is-toggled' );
 			} );
+
+			app.$switcher.on( 'select2:close', function() {
+				app.$outerContainer.removeClass( 'is-toggled' );
+			} )
 
 			app.$notice.on( 'click', '.wp20-locale-notice-dismiss', function( event ) {
 				event.preventDefault();

--- a/wp-content/themes/twentyseventeen-wp20/assets/js/front-end.js
+++ b/wp-content/themes/twentyseventeen-wp20/assets/js/front-end.js
@@ -27,12 +27,12 @@
 			}
 
 			// Change button text when menu toggle is clicked
-			app.$menuToggle.on('click', function () {
-				if( $(this).hasClass( 'toggled-on' ) ) {
+			app.$menuToggle.on( 'click', function() {
+				if ( $( this ).hasClass( 'toggled-on' ) ) {
 					$( this ).removeClass( 'toggled-on' ).children( 'span' ).text( menuTitle );
 				} else {
-					menuTitle = $(this).text();
-					$(this).addClass( 'toggled-on' ).children('span').text( 'Menu' );
+					menuTitle = $( this ).text();
+					$( this ).addClass( 'toggled-on' ).children( 'span' ).text( 'Menu' );
 				}
 			});
 
@@ -41,14 +41,15 @@
 				var $target = $( event.target );
 
 				if ( ! $target.closest( app.$menuToggle ).length && 
-				! $target.closest( app.$menuDropdown ).length && 
-				app.$menuDropdown.hasClass( 'toggled-on' ) ) {
+					! $target.closest( app.$menuDropdown ).length && 
+					app.$menuDropdown.hasClass( 'toggled-on' )
+				) {
 					app.$menuDropdown.removeClass( 'toggled-on' );
 				}
 			});
 		},
 
-		observerCallback: function( events ) {
+		observerCallback: function ( events ) {
 			$.each( events, function ( i, event ) {
 				var $target = $( event.target );
 

--- a/wp-content/themes/twentyseventeen-wp20/assets/js/front-end.js
+++ b/wp-content/themes/twentyseventeen-wp20/assets/js/front-end.js
@@ -9,11 +9,12 @@
 		classValue: 'site-navigation-fixed',
 
 		init: function() {
-			var observer;
+			var observer, menuTitle;
 
 			app.$nav          = app.$body.find( '.navigation-top' );
 			app.$navContainer = app.$body.find( '.navigation-top-container' );
 			app.$siteContent  = app.$body.find( '.site-content-contain' );
+			app.$menuToggle   = $( '.menu-toggle' );
 
 			observer = new MutationObserver( app.observerCallback );
 
@@ -23,6 +24,15 @@
 					attributeFilter: [ 'class' ]
 				} );
 			}
+
+			app.$menuToggle.on('click', function () {
+				if( $(this).hasClass( 'toggle-on' ) ) {
+					$(this).removeClass( 'toggle-on' ).children('span').text(menuTitle);;
+				} else {
+					menuTitle = $(this).text();
+					$(this).addClass( 'toggle-on' ).children('span').text( 'Menu' );
+				}
+			});
 		},
 
 		observerCallback: function( events ) {

--- a/wp-content/themes/twentyseventeen-wp20/assets/js/front-end.js
+++ b/wp-content/themes/twentyseventeen-wp20/assets/js/front-end.js
@@ -29,7 +29,7 @@
 			// Change button text when menu toggle is clicked
 			app.$menuToggle.on('click', function () {
 				if( $(this).hasClass( 'toggled-on' ) ) {
-					$(this).removeClass( 'toggled-on' ).children('span').text(menuTitle);;
+					$( this ).removeClass( 'toggled-on' ).children( 'span' ).text( menuTitle );
 				} else {
 					menuTitle = $(this).text();
 					$(this).addClass( 'toggled-on' ).children('span').text( 'Menu' );

--- a/wp-content/themes/twentyseventeen-wp20/assets/js/front-end.js
+++ b/wp-content/themes/twentyseventeen-wp20/assets/js/front-end.js
@@ -15,6 +15,7 @@
 			app.$navContainer = app.$body.find( '.navigation-top-container' );
 			app.$siteContent  = app.$body.find( '.site-content-contain' );
 			app.$menuToggle   = $( '.menu-toggle' );
+			app.$menuDropdown = $( '.main-navigation' );
 
 			observer = new MutationObserver( app.observerCallback );
 
@@ -25,12 +26,24 @@
 				} );
 			}
 
+			// Change button text when menu toggle is clicked
 			app.$menuToggle.on('click', function () {
 				if( $(this).hasClass( 'toggle-on' ) ) {
 					$(this).removeClass( 'toggle-on' ).children('span').text(menuTitle);;
 				} else {
 					menuTitle = $(this).text();
 					$(this).addClass( 'toggle-on' ).children('span').text( 'Menu' );
+				}
+			});
+
+			// When clicking outside of the dropdown menu, close the dropdown menu
+			$( document ).click( function( event ) {
+				var $target = $( event.target );
+
+				if ( ! $target.closest( app.$menuToggle ).length && 
+				! $target.closest( app.$menuDropdown ).length && 
+				app.$menuDropdown.hasClass( 'toggled-on' ) ) {
+					app.$menuDropdown.removeClass( 'toggled-on' );
 				}
 			});
 		},

--- a/wp-content/themes/twentyseventeen-wp20/assets/js/front-end.js
+++ b/wp-content/themes/twentyseventeen-wp20/assets/js/front-end.js
@@ -28,11 +28,11 @@
 
 			// Change button text when menu toggle is clicked
 			app.$menuToggle.on('click', function () {
-				if( $(this).hasClass( 'toggle-on' ) ) {
-					$(this).removeClass( 'toggle-on' ).children('span').text(menuTitle);;
+				if( $(this).hasClass( 'toggled-on' ) ) {
+					$(this).removeClass( 'toggled-on' ).children('span').text(menuTitle);;
 				} else {
 					menuTitle = $(this).text();
-					$(this).addClass( 'toggle-on' ).children('span').text( 'Menu' );
+					$(this).addClass( 'toggled-on' ).children('span').text( 'Menu' );
 				}
 			});
 

--- a/wp-content/themes/twentyseventeen-wp20/assets/js/front-end.js
+++ b/wp-content/themes/twentyseventeen-wp20/assets/js/front-end.js
@@ -18,6 +18,7 @@
 			app.$menuDropdown = $( '.main-navigation' );
 
 			observer = new MutationObserver( app.observerCallback );
+			menuTitle = app.$menuToggle.text();
 
 			if ( app.$navContainer.length ) {
 				observer.observe( app.$nav.get(0), {
@@ -31,7 +32,6 @@
 				if ( $( this ).hasClass( 'toggled-on' ) ) {
 					$( this ).removeClass( 'toggled-on' ).children( 'span' ).text( menuTitle );
 				} else {
-					menuTitle = $( this ).text();
 					$( this ).addClass( 'toggled-on' ).children( 'span' ).text( 'Menu' );
 				}
 			});
@@ -45,6 +45,7 @@
 					app.$menuDropdown.hasClass( 'toggled-on' )
 				) {
 					app.$menuDropdown.removeClass( 'toggled-on' );
+					app.$menuToggle.removeClass( 'toggled-on' ).attr( 'aria-expanded', false ).children( 'span' ).text( menuTitle );
 				}
 			});
 		},

--- a/wp-content/themes/twentyseventeen-wp20/header.php
+++ b/wp-content/themes/twentyseventeen-wp20/header.php
@@ -22,11 +22,15 @@ use WP20\Locales;
 			<?php get_template_part( 'template-parts/header/header', 'image' ); ?>
 
 			<?php if ( has_nav_menu( 'top' ) ) : ?>
-				<div class="navigation-top wrap wrap-wide">
-					<?php get_template_part( 'template-parts/header/navigation', 'top' ); ?>
-					<?php Locales\locale_switcher(); ?>
+				<div class="navigation-top-container">
+					<div class="navigation-top">
+						<div class="wrap wrap-wide">
+							<?php get_template_part( 'template-parts/header/navigation', 'top' ); ?>
+							<?php Locales\locale_switcher(); ?>
+						</div>
+					</div>
+					<div class="navigation-top-menu-container" data-placeholder="<?php esc_attr_e( 'Search languages...', 'wp20' ); ?>"></div>
 				</div>
-				<div class="navigation-top-menu-container" data-placeholder="<?php esc_attr_e( 'Search languages...', 'wp20' ); ?>"></div>
 			<?php endif; ?>
 		</header>
 

--- a/wp-content/themes/twentyseventeen-wp20/header.php
+++ b/wp-content/themes/twentyseventeen-wp20/header.php
@@ -27,9 +27,9 @@ use WP20\Locales;
 						<div class="wrap wrap-wide">
 							<?php get_template_part( 'template-parts/header/navigation', 'top' ); ?>
 							<?php Locales\locale_switcher(); ?>
+							<div class="navigation-top-menu-container" data-placeholder="<?php esc_attr_e( 'Search languages...', 'wp20' ); ?>"></div>
 						</div>
 					</div>
-					<div class="navigation-top-menu-container" data-placeholder="<?php esc_attr_e( 'Search languages...', 'wp20' ); ?>"></div>
 				</div>
 			<?php endif; ?>
 		</header>

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -531,7 +531,7 @@ body.page .entry-header {
 
 .menu-toggle:focus, 
 .menu-toggle:hover {
-	background: #F7F7F7 !important;
+	background: var(--wp20--color--active-menu) !important;
 	outline: none;
 }
 
@@ -585,17 +585,12 @@ body.page .entry-header {
 	text-align: right;
 	height: 55px;
 	line-height: 55px;
+	width: 50%;
 }
 
 @media screen and (max-width:47em) {
-	.wp20-locale-switcher-container:focus-within {
-		background: #F7F7F7;
-		width: 50%;
-	}
-
-	.wp20-locale-switcher-container:focus-within .select2-selection__rendered {
-		font-weight: 700;
-		text-decoration: none;
+	.wp20-locale-switcher-container.is-toggled {
+		background: var(--wp20--color--active-menu);
 	}
 }
 
@@ -630,6 +625,12 @@ body.page .entry-header {
 
 .wp20-locale-switcher-container .select2-container .select2-selection--single .select2-selection__rendered {
 	padding-right: 22px !important;
+	color: var(--wp20--color--grey-6);
+}
+
+.wp20-locale-switcher-container .select2-container--open .select2-selection--single .select2-selection__rendered {
+	color: var(--wp20--color--text);
+	font-weight: 700;
 }
 
 .wp20-locale-switcher-container.select2-selection--single .select2-selection__rendered {

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -25,7 +25,7 @@ Template:    twentyseventeen
 	--wp20--color--text-link: var(--wp20--color--blueberry);
 	--wp20--color--border: var(--wp20--color--grey-8);
 	--wp20--color--card-background: var(--wp20--color--grey-9);
-	--wp20--color--active-menu: #F7F7F7;
+	--wp20--color--active-menu: var(--wp20--color--grey-9);
 
 	--wp20--spacing--xxxsmall: 8px;
 	--wp20--spacing--xxsmall: 15px;
@@ -422,9 +422,8 @@ body.page .entry-header {
 	}
 }
 
-/* Override base styles */
+/* Override styles from twentyseventeen */
 .navigation-top .wrap {
-	box-sizing: content-box;
 	padding: 0;
 }
 

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -25,6 +25,7 @@ Template:    twentyseventeen
 	--wp20--color--text-link: var(--wp20--color--blueberry);
 	--wp20--color--border: var(--wp20--color--grey-8);
 	--wp20--color--card-background: var(--wp20--color--grey-9);
+	--wp20--color--active-menu: #F7F7F7;
 
 	--wp20--spacing--xxxsmall: 8px;
 	--wp20--spacing--xxsmall: 15px;
@@ -486,10 +487,6 @@ body.page .entry-header {
 	font-size: 14px;
 }
 
-.main-navigation.toggled-on .menu-top-menu-container li a {
-	color: var(--wp20--color--text);
-}
-
 @media screen and (max-width: 767px) {
 	.main-navigation li {
 		padding: 0 var(--wp20--spacing--xsmall);
@@ -576,7 +573,16 @@ body.page .entry-header {
 	top: 0 !important;
 }
 
+.navigation-top-menu-container .select2-dropdown {
+	border-top: 1px solid var(--wp20--color--border) !important;
+}
+
 @media screen and (min-width: 769px) {
+	.navigation-top-menu-container {
+		margin: 0 var(--wp20--spacing--edge-space) 0;
+		max-width: calc( var(--wp20--screen-width-wide) + var(--wp20--spacing--edge-space) * 2 );
+	}
+
 	.navigation-top-menu-container > * {
 		position: absolute !important;
 		left: auto !important;

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -552,11 +552,11 @@ body.page .entry-header {
 	height: 15px;
 }
 
-.menu-toggle.toggle-on {
+.menu-toggle.toggled-on {
 	background: var(--wp20--color--active-menu) !important; /* Override TT17 Rule */
 }
 
-.menu-toggle.toggle-on > span {
+.menu-toggle.toggled-on > span {
 	font-weight: 700;
 }
 

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -421,6 +421,19 @@ body.page .entry-header {
 	}
 }
 
+/* Override base styles */
+.navigation-top .wrap {
+	box-sizing: content-box;
+	padding: 0;
+}
+
+@media screen and (min-width: 48em) {
+	.navigation-top .wrap {
+		padding-left: var(--wp20--spacing--edge-space);
+		padding-right: var(--wp20--spacing--edge-space);
+	}
+}
+
 .navigation-top > * {
 	flex-basis: 50%;
 }

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -424,13 +424,21 @@ body.page .entry-header {
 }
 
 .navigation-top a {
+	color: var(--wp20--color--text);
 	font-weight: 400;
 }
 
 .navigation-top .current-menu-item > a,
 .navigation-top .current_page_item > a {
-	color: var(--wp20--color--text);
+	color: var(--wp20--color--primary);
 	font-weight: 700;
+}
+
+@media screen and (min-width: 48em) {
+	.navigation-top .current-menu-item > a,
+	.navigation-top .current_page_item > a {
+		color: var(--wp20--color--text);
+	}
 }
 
 .site-navigation-fixed.navigation-top {

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -719,7 +719,7 @@ body.page .entry-header {
 
 .navigation-top-menu-container .select2-container--default .select2-results__option[aria-selected=true] {
 	color: var(--wp20--color--text-link) !important;
-	font-weight: 500;
+	font-weight: 700;
 }
 
 /*

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -559,7 +559,6 @@ body.page .entry-header {
 .navigation-top-menu-container > * {
 	position: relative !important;
 	width: 100% !important;
-	top: 0 !important;
 	left: 0 !important;
 }
 
@@ -567,7 +566,7 @@ body.page .entry-header {
 	.navigation-top-menu-container > * {
 		position: absolute !important;
 		left: auto !important;
-		right: var(--wp20--spacing--edge-space) !important;
+		right: 0 !important;
 		width: 50% !important;
 		max-width: 400px;
 	}
@@ -582,6 +581,7 @@ body.page .entry-header {
 	top: 0;
 	right: 0;
 	margin: 0 auto;
+	padding-right: inherit;
 	text-align: right;
 	height: 55px;
 	line-height: 55px;
@@ -608,7 +608,7 @@ body.page .entry-header {
 
 @media screen and (min-width: 769px) {
 	.wp20-locale-switcher-container .select2-container {
-		margin-right: var(--wp20--spacing--edge-space);
+		margin-right: 0;
 	}
 }
 

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -599,7 +599,6 @@ body.page .entry-header {
 	text-align: right;
 	height: 55px;
 	line-height: 55px;
-	width: 50%;
 }
 
 @media screen and (max-width:47em) {

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -419,13 +419,16 @@ body.page .entry-header {
 	}
 
 	.navigation-top nav {
+		line-height: 26px;
 		margin-left: calc(var(--wp20--spacing--xxxsmall) * -1);
 	}
 }
 
-/* Override styles from twentyseventeen */
-.navigation-top .wrap {
-	padding: 0 var(--wp20--spacing--edge-space);
+@media screen and (min-width: 769px) {
+	/* Override styles from twentyseventeen */
+	.navigation-top .wrap {
+		padding: 0 var(--wp20--spacing--edge-space);
+	}
 }
 
 .navigation-top > * {
@@ -510,7 +513,7 @@ body.page .entry-header {
 
 .menu-toggle {
 	margin: 0;
-	padding: var(--wp20--spacing--menu-spacing) 0;
+	padding: var(--wp20--spacing--menu-spacing) var(--wp20--spacing--edge-space);
 	color: var(--wp20--color--text);
 	font-weight: 400;
 	text-align: left;
@@ -518,6 +521,7 @@ body.page .entry-header {
 	width: 50%;
 	box-sizing: border-box;
 	font-family: 'Inter', sans-serif; /* Override TT17 Rule */
+	line-height: 26px;
 }
 
 /* TT17 Rule */
@@ -593,13 +597,23 @@ body.page .entry-header {
 	position: absolute;
 	top: 0;
 	right: 0;
-	margin: 0 auto;
-	padding-right: inherit;
 	text-align: right;
-	line-height: 52px;
+	width: 50%;
 }
 
-@media screen and (max-width:47em) {
+@media screen and (min-width: 769px) {
+	.wp20-locale-switcher-container {
+		right: 80px;
+	}
+}
+
+@media screen and (max-width: 768px) {
+	.wp20-locale-switcher-container:hover {
+		background: var(--wp20--color--active-menu);
+	}
+}
+
+@media screen and (max-width:768px) {
 	.wp20-locale-switcher-container.is-toggled {
 		background: var(--wp20--color--active-menu);
 	}
@@ -613,17 +627,20 @@ body.page .entry-header {
 	visibility: hidden; /* Prevent iOS native picker UI */
 }
 
-@media screen and (min-width: 769px) {
+@media screen and (max-width: 768px) {
 	.wp20-locale-switcher-container .select2-container {
-		margin-right: 0;
+		width: 100% !important; /* override selectWoo rule. locale-swithcer.js L24. */
 	}
 }
 
 .wp20-locale-switcher-container .select2-container--default .select2-selection--single {
 	border: none;
-	height: auto;
+	height: 60px;
 	background: transparent;
 	text-align:right;
+	display: flex;
+	align-items: center;
+	justify-content: flex-end;
 }
 
 /* The select language label */
@@ -660,7 +677,18 @@ body.page .entry-header {
 	}
 }
 
+@media screen and (max-width: 768px) {
+	#wp20-locale-switcher-form {
+		padding-right: var(--wp20--spacing--edge-space);
+	}
+}
+
 /* Arrow indicators */
+.select2-container--default .select2-selection--single .select2-selection__arrow {
+	top: unset !important;
+}
+
+
 .wp20-locale-switcher-container .select2-selection--single .select2-selection__arrow b {
 	width: 5px !important;
 	height: 5px !important;
@@ -672,14 +700,6 @@ body.page .entry-header {
 
 .wp20-locale-switcher-container .select2-container--open .select2-selection--single .select2-selection__arrow b {
 	transform: rotate(-45deg) !important;
-}
-
-@media screen and (min-width: 769px) {
-	.wp20-locale-switcher-container {
-		position: absolute;
-		top: 0;
-		right: 0;
-	}
 }
 
 /*

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -577,11 +577,6 @@ body.page .entry-header {
 }
 
 @media screen and (min-width: 769px) {
-	.navigation-top-menu-container {
-		margin: 0 var(--wp20--spacing--edge-space) 0;
-		max-width: calc( var(--wp20--screen-width-wide) + var(--wp20--spacing--edge-space) * 2 );
-	}
-
 	.navigation-top-menu-container > * {
 		position: absolute !important;
 		left: auto !important;

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -404,6 +404,7 @@ body.page .entry-header {
 	z-index: 20;
 	background: #fff;
 	border: unset;
+	font-size: 14px;
 }
 
 @media screen and (max-width: 48em) {

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -23,7 +23,7 @@ Template:    twentyseventeen
 	--wp20--color--text: var(--wp20--color--grey-0);
 	--wp20--color--text-meta: var(--wp20--color--grey-6);
 	--wp20--color--text-link: var(--wp20--color--blueberry);
-	--wp20--color--border: var(--wp20--color--grey-8);
+	--wp20--color--border: rgba(0, 0, 0, 0.1);
 	--wp20--color--card-background: var(--wp20--color--grey-9);
 	--wp20--color--active-menu: var(--wp20--color--grey-9);
 
@@ -47,7 +47,12 @@ Template:    twentyseventeen
  * Base
  */
 
-body {
+body,
+button,
+input,
+select,
+textarea,
+input::placeholder {
 	font-family: 'Inter', sans-serif;
 	font-size: 13px;
 	line-height: 1.4;
@@ -698,16 +703,14 @@ body.page .entry-header {
 
 
 .wp20-locale-switcher-container .select2-selection--single .select2-selection__arrow b {
-	width: 5px !important;
-	height: 5px !important;
-	border: 1px solid var(--wp20--color--grey-0) !important;
+	width: 6px !important;
+	height: 6px !important;
+	border: 1px solid var(--wp20--color--text) !important;
 	border-bottom: none !important;
 	border-left: none !important;
 	transform: rotate(135deg) !important;
-}
-
-.wp20-locale-switcher-container .select2-container--open .select2-selection--single .select2-selection__arrow b {
-	transform: rotate(-45deg) !important;
+	margin-left: -2px !important;
+	margin-top: -4px !important;
 }
 
 /*
@@ -728,18 +731,22 @@ body.page .entry-header {
 	padding: 0;
 }
 
-.navigation-top-menu-container  .select2-search--dropdown .select2-search__field {
-	padding: 12px 40px 12px 12px;
+.navigation-top-menu-container .select2-search--dropdown .select2-search__field {
+	padding: 13px 50px 13px 12px;
 	border-radius: 0;
 	border: 0 !important;
 	border-bottom: 1px solid var(--wp20--color--border) !important;
 	color: var(--wp20--color--text);
 	background-image:  url( 'images/search-icon.svg' );
 	background-repeat: no-repeat;
-	background-size: 12px 12px;
+	background-size: 13px;
 	background-position: calc(100% - 20px) center;
 	font-size: 14px;
-	text-align: right;
+	text-align: end;
+}
+
+.navigation-top-menu-container .select2-search--dropdown .select2-search__field::placeholder {
+	font-size: 14px;
 }
 
 .navigation-top-menu-container  .select2-search--dropdown .select2-search__field::placeholder {

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -34,6 +34,8 @@ Template:    twentyseventeen
 	--wp20--spacing--large: 80px;
 	--wp20--spacing--edge-space: var(--wp20--spacing--xsmall);
 
+	--wp20--spacing--menu-spacing: 17px;
+
 	--wp20--screen-width: 940px;
 	--wp20--screen-width-wide: 1160px;
 
@@ -505,6 +507,7 @@ body.page .entry-header {
 
 .menu-toggle {
 	margin: 0;
+	padding: var(--wp20--spacing--menu-spacing) var(--wp20--spacing--edge-space);
 	color: var(--wp20--color--text);
 	font-weight: 400;
 	text-align: left;
@@ -579,8 +582,8 @@ body.page .entry-header {
 	right: 0;
 	margin: 0 auto;
 	text-align: right;
-	height: 49px;
-	line-height: 49px;
+	height: 55px;
+	line-height: 55px;
 }
 
 @media screen and (max-width:47em) {

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -619,8 +619,18 @@ body.page .entry-header {
 	text-align:right;
 }
 
+/* The select language label */
 .wp20-locale-switcher-container .select2-selection .select2-selection__rendered {
 	font-size: 14px;
+	max-width: 150px;
+	text-overflow: ellipsis;
+}
+
+/* Remove the ellipsis overflow */
+@media screen and (min-width: 375px) {
+	.wp20-locale-switcher-container .select2-selection .select2-selection__rendered {
+		max-width: unset;
+	}
 }
 
 .wp20-locale-switcher-container .select2-container .select2-selection--single .select2-selection__rendered {

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -424,14 +424,7 @@ body.page .entry-header {
 
 /* Override styles from twentyseventeen */
 .navigation-top .wrap {
-	padding: 0;
-}
-
-@media screen and (min-width: 48em) {
-	.navigation-top .wrap {
-		padding-left: var(--wp20--spacing--edge-space);
-		padding-right: var(--wp20--spacing--edge-space);
-	}
+	padding: 0 var(--wp20--spacing--edge-space);
 }
 
 .navigation-top > * {
@@ -516,7 +509,7 @@ body.page .entry-header {
 
 .menu-toggle {
 	margin: 0;
-	padding: var(--wp20--spacing--menu-spacing) var(--wp20--spacing--edge-space);
+	padding: var(--wp20--spacing--menu-spacing) 0;
 	color: var(--wp20--color--text);
 	font-weight: 400;
 	text-align: left;
@@ -597,8 +590,7 @@ body.page .entry-header {
 	margin: 0 auto;
 	padding-right: inherit;
 	text-align: right;
-	height: 55px;
-	line-height: 55px;
+	line-height: 52px;
 }
 
 @media screen and (max-width:47em) {
@@ -613,10 +605,6 @@ body.page .entry-header {
 
 .wp20-locale-switcher-container select {
 	visibility: hidden; /* Prevent iOS native picker UI */
-}
-
-.wp20-locale-switcher-container .select2-container {
-	margin-right: var(--wp20--spacing--xxxsmall);
 }
 
 @media screen and (min-width: 769px) {

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -573,6 +573,7 @@ body.page .entry-header {
 	position: relative !important;
 	width: 100% !important;
 	left: 0 !important;
+	top: 0 !important;
 }
 
 @media screen and (min-width: 769px) {

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -513,6 +513,7 @@ body.page .entry-header {
 	text-align: left;
 	border-radius: 0;
 	width: 50%;
+	box-sizing: border-box;
 }
 
 /* TT17 Rule */

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -517,6 +517,7 @@ body.page .entry-header {
 	border-radius: 0;
 	width: 50%;
 	box-sizing: border-box;
+	font-family: 'Inter', sans-serif; /* Override TT17 Rule */
 }
 
 /* TT17 Rule */
@@ -541,6 +542,10 @@ body.page .entry-header {
 .menu-toggle > img {
 	width: 15px;
 	height: 15px;
+}
+
+.menu-toggle.toggle-on > span {
+	font-weight: 700;
 }
 
 .menu-toggle[aria-expanded="true"] .icon-bars {

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -426,6 +426,7 @@ body.page .entry-header {
 .navigation-top a {
 	color: var(--wp20--color--text);
 	font-weight: 400;
+	padding: 12px 0;
 }
 
 .navigation-top .current-menu-item > a,
@@ -465,7 +466,6 @@ body.page .entry-header {
 }
 
 .main-navigation.toggled-on .menu-top-menu-container li {
-	padding: 12px var(--wp20--spacing--edge-space);
 	border-top: 1px solid var(--wp20--color--border);
 	border-bottom: 0;
 	font-size: 14px;

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -537,15 +537,23 @@ body.page .entry-header {
 	}
 }
 
-.menu-toggle:focus, 
+.menu-toggle:focus {
+	background: unset !important; /* Override TT17 Rule */
+	outline: none;
+}
+
 .menu-toggle:hover {
-	background: var(--wp20--color--active-menu) !important;
+	background: var(--wp20--color--active-menu) !important; /* Override TT17 Rule */
 	outline: none;
 }
 
 .menu-toggle > img {
 	width: 15px;
 	height: 15px;
+}
+
+.menu-toggle.toggle-on {
+	background: var(--wp20--color--active-menu) !important; /* Override TT17 Rule */
 }
 
 .menu-toggle.toggle-on > span {

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -413,8 +413,15 @@ body.page .entry-header {
 }
 
 @media screen and (max-width: 48em) {
-	.navigation-top {
+	.navigation-top,
+	.navigation-top .wrap {
 		padding: 0;
+	}
+}
+
+@media screen and (min-width: 48em) {
+	.navigation-top nav {
+		margin-left: 0;
 	}
 }
 
@@ -423,16 +430,13 @@ body.page .entry-header {
 		width: unset;
 	}
 
+	.navigation-top .wrap {
+		padding: 0 var(--wp20--spacing--edge-space);
+	}
+
 	.navigation-top nav {
 		line-height: 26px;
 		margin-left: calc(var(--wp20--spacing--xxxsmall) * -1);
-	}
-}
-
-@media screen and (min-width: 769px) {
-	/* Override styles from twentyseventeen */
-	.navigation-top .wrap {
-		padding: 0 var(--wp20--spacing--edge-space);
 	}
 }
 
@@ -448,14 +452,14 @@ body.page .entry-header {
 
 .navigation-top .current-menu-item > a,
 .navigation-top .current_page_item > a {
-	color: var(--wp20--color--primary);
 	font-weight: 700;
+	color: var(--wp20--color--text);
 }
 
-@media screen and (min-width: 48em) {
+@media screen and (max-width: 48em) {
 	.navigation-top .current-menu-item > a,
 	.navigation-top .current_page_item > a {
-		color: var(--wp20--color--text);
+		color: var(--wp20--color--primary);
 	}
 }
 
@@ -470,6 +474,7 @@ body.page .entry-header {
 }
 
 .main-navigation > div > ul {
+	border-top: 1px solid var(--wp20--color--border);
 	padding: 0;
 }
 
@@ -488,15 +493,32 @@ body.page .entry-header {
 	font-size: 14px;
 }
 
-@media screen and (max-width: 767px) {
+@media screen and (max-width: 48em) {
 	.main-navigation li {
 		padding: 0 var(--wp20--spacing--xsmall);
+		display: block;
+		border-bottom: 1px solid var(--wp20--color--border);
+	}
+}
+
+@media screen and (min-width: 48em) {
+	.js .main-navigation ul,
+	.js .main-navigation ul ul,
+	.js .main-navigation > div > ul {
+		display: none;
 	}
 }
 
 @media screen and (min-width: 769px) {
 	.main-navigation {
 		background-color: #fff;
+	}
+
+	.js .main-navigation ul,
+	.js .main-navigation ul ul,
+	.js .main-navigation > div > ul {
+		display: block;
+		border-top: 0;
 	}
 
 	.main-navigation a {
@@ -620,13 +642,13 @@ body.page .entry-header {
 	}
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 48em) {
 	.wp20-locale-switcher-container:hover {
 		background: var(--wp20--color--active-menu);
 	}
 }
 
-@media screen and (max-width:768px) {
+@media screen and (max-width:48em) {
 	.wp20-locale-switcher-container.is-toggled {
 		background: var(--wp20--color--active-menu);
 	}
@@ -640,7 +662,7 @@ body.page .entry-header {
 	visibility: hidden; /* Prevent iOS native picker UI */
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 48em) {
 	.wp20-locale-switcher-container .select2-container {
 		width: 100% !important; /* override selectWoo rule. locale-swithcer.js L24. */
 	}
@@ -690,7 +712,7 @@ body.page .entry-header {
 	}
 }
 
-@media screen and (max-width: 768px) {
+@media screen and (max-width: 48em) {
 	#wp20-locale-switcher-form {
 		padding-right: var(--wp20--spacing--edge-space);
 	}

--- a/wp-content/themes/twentyseventeen-wp20/template-parts/header/navigation-top.php
+++ b/wp-content/themes/twentyseventeen-wp20/template-parts/header/navigation-top.php
@@ -3,10 +3,11 @@
  * Displays top navigation
  */
 
+
 ?>	<button class="menu-toggle" aria-controls="top-menu" aria-expanded="false">
 		<img class="icon-bars" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/images/menu-icon.svg" aria-hidden="true"  />
 		<img class="icon-close" src="<?php echo esc_url( get_stylesheet_directory_uri() ); ?>/images/close-icon.svg" aria-hidden="true" />
-		<span><?php _e( 'Menu', 'wp20' ); ?></span>
+		<span><?php esc_html_e( get_the_title() ); ?></span>
 </button>
 
 <nav id="site-navigation" class="main-navigation" aria-label="<?php esc_attr_e( 'Top Menu', 'wp20' ); ?>">


### PR DESCRIPTION
Fixes: #1 

**To do**

- [x] The dropdown menu falls out of alignment as the viewport expands.
- [x] The active menu item should switch on open. [Reference](https://github.com/WordPress/wp20.wordpress.net/issues/1#issuecomment-1486312752)
- [x] Try, making the word "menu" bold when the menu is toggled open. [Context](https://www.figma.com/file/3veAfpzTQ82v8G3sbvaJZh/WP20-Anniversary?node-id=1476-11025&t=kXk6lQTX5Nc35riF-0)