### PR TITLE
Scroll to map to inform user of filtering

### DIFF
--- a/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.js
+++ b/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.js
@@ -439,14 +439,16 @@ var WP20MeetupEvents = app = ( function( $ ) {
 
 		filterEventList( this.value );
 
-		/*
-		 * Sometimes the map may be taking up most of the viewport, so the user won't see the list changing as
-		 * they type their query. This helps direct them to the results.
-		 */
-		event.target.scrollIntoView( {
-			inline: 'start',
-			behavior: 'smooth',
-		} );
+		_.debounce( function() {
+			/*
+			* Sometimes the map may be taking up most of the viewport, so the user won't see the list changing as
+			* they type their query. This helps direct them to the results.
+			*/
+			event.target.scrollIntoView( {
+				inline: 'start',
+				behavior: 'smooth',
+			} );
+		}, 300 )();
 	}
 
 	/**

--- a/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.js
+++ b/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.js
@@ -20,7 +20,7 @@ var WP20MeetupEvents = app = ( function( $ ) {
 	    map,
 	    markers,
 	    markerCluster,
-		searchQuery,
+	    searchQuery,
 	    templateOptions = {
 			evaluate:    /<#([\s\S]+?)#>/g,
 			interpolate: /\{\{\{([\s\S]+?)\}\}\}/g,
@@ -35,7 +35,7 @@ var WP20MeetupEvents = app = ( function( $ ) {
 		options = data.map_options;
 		strings = data.strings;
 
-		var debouncedHandleFilterEvent = _.debounce( handleFilterInput, 300 );
+		var debouncedHandleFilterEvent = _.debounce( handleFilterInput, 200 );
 
 		try {
 			$( '#wp20-events-query-mobile' ).keyup( debouncedHandleFilterEvent );
@@ -440,25 +440,22 @@ var WP20MeetupEvents = app = ( function( $ ) {
 	function handleFilterInput( event ) {
 		event.preventDefault();
 
-		// On submit this is called twice, once with the form and once with the input. We only want to handle the input.
-		// We also don't want to handle `keyup` events that aren't searches, like `alt-tab`.
-		if ( undefined === event.target.value || event.target.value === app.searchQuery ) {
+		// We don't want to handle `keyup` events that aren't searches, like `alt-tab`.
+		if ( event.target.value === app.searchQuery ) {
 			return;
-			// this prevents submit from scrolling to map/list if they scrolled away, so there's no point in listening for submit
-			// fix that or just remove the submit handler
 		}
 
-		app.searchQuery = event.target.value;
-
-		filterEventList( app.searchQuery );
-
-		// console.log( event.target.value	);
-		// console.log( event.target );
+		// On submit this is called twice, once with the `form` and once with the `input`. The `form` wont have a
+		// value to filter by, so it can be ignored. It should still trigger a scroll though.
+		if ( undefined !== event.target.value ) {
+			app.searchQuery = event.target.value;
+			filterEventList( app.searchQuery );
+		}
 
 		/*
-		* Sometimes the map may be taking up most of the viewport, so the user won't see the list changing as
-		* they type their query. This helps direct them to the results.
-		*/
+		 * Sometimes the map may be taking up most of the viewport, so the user won't see the list changing as
+		 * they type their query. This helps direct them to the results.
+		 */
 		event.target.scrollIntoView( {
 			inline: 'start',
 			behavior: 'smooth',

--- a/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.js
+++ b/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.js
@@ -35,8 +35,9 @@ var WP20MeetupEvents = app = ( function( $ ) {
 		strings = data.strings;
 
 		try {
-			$( '#wp20-events-query-mobile' ).keyup( filterEventList );
-			$( '#wp20-events-query-desktop' ).keyup( filterEventList );
+			$( '#wp20-events-query-mobile' ).keyup( handleFilterInput );
+			$( '#wp20-events-query-desktop' ).keyup( handleFilterInput );
+			$( '#wp20-events-filter' ).submit( handleFilterInput );
 
 			if ( options.hasOwnProperty( 'mapContainer' ) ) {
 				loadMap( options.mapContainer, events );
@@ -429,11 +430,30 @@ var WP20MeetupEvents = app = ( function( $ ) {
 	}
 
 	/**
+	 * Handle user input in the filter form.
+	 *
+	 * @param {object} event
+	 */
+	function handleFilterInput( event ) {
+		event.preventDefault();
+
+		filterEventList( this.value );
+
+		/*
+		 * Sometimes the map may be taking up most of the viewport, so the user won't see the list changing as
+		 * they type their query. This helps direct them to the results.
+		 */
+		event.target.scrollIntoView( {
+			inline: 'start',
+			behavior: 'smooth',
+		} );
+	}
+
+	/**
 	 * Filter the list of events based on a user's search query.
 	 */
-	function filterEventList() {
-		var query  = this.value,
-		    events = $( '.wp20-events-list' ).children( 'li' );
+	function filterEventList( query ) {
+		var events = $( '.wp20-events-list' ).children( 'li' );
 		    speak  = _.debounce( wp.a11y.speak, 1000 );
 		var noMatches = $( '.wp20-events-list-no-results' );
 		var countHidden = 0;


### PR DESCRIPTION
Fixes #42

The filter form appears above the map, and the map may take up the whole viewport. If that happens, the user may not notice the list is filtering as they type, and may be confused. This scrolls down to the map when they type or submit, to make it more obvious. 

The viewport is also scrolled if they submit the form. That's an edge case, but it doesn't hurt to cover it.

The horizontal scrolling wasn't introduced in this PR, it appears in `trunk`. I opened #51 to track it.

![scroll](https://user-images.githubusercontent.com/484068/230506714-356dda20-e525-4fed-b850-81644f664251.gif)
