### PR TITLE
Filter map events as user types

### DIFF
--- a/wp-content/plugins/wp20-meetup-events/views/events-list.php
+++ b/wp-content/plugins/wp20-meetup-events/views/events-list.php
@@ -14,7 +14,10 @@ defined( 'WPINC' ) || die();
 
 <ul class="wp20-events-list">
 	<?php foreach ( $events as $event ) : ?>
-		<li data-location="<?php echo esc_attr( $event['location'] ); ?>">
+		<li
+			data-name="<?php echo esc_attr( $event['name'] ); ?>"
+			data-location="<?php echo esc_attr( $event['location'] ); ?>"
+		>
 			<h3 class="wp20-event-group">
 				<?php echo Theme\prevent_widows_in_content( esc_html( $event['group'] ) ); ?>
 			</h3>

--- a/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.js
+++ b/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.js
@@ -450,6 +450,7 @@ var WP20MeetupEvents = app = ( function( $ ) {
 		if ( undefined !== event.target.value ) {
 			app.searchQuery = event.target.value;
 			filterEventList( app.searchQuery );
+			filterEventMap( this.value );
 		}
 
 		/*
@@ -460,6 +461,25 @@ var WP20MeetupEvents = app = ( function( $ ) {
 			inline: 'start',
 			behavior: 'smooth',
 		} );
+	}
+
+	/**
+	 * Filter the map markers based on a user's search query.
+	 *
+	 * @param {string} query
+	 */
+	function filterEventMap( query ) {
+		var haystack;
+
+		app.markerCluster.clearMarkers();
+
+		for ( var markerID in app.markers ) {
+			haystack = app.markers[ markerID ].group + ' ' + app.markers[ markerID ].name + ' ' + app.markers[ markerID ].location;
+
+			if ( eventMatchesQuery( haystack, query ) ) {
+				app.markerCluster.addMarker( app.markers[ markerID ] );
+			}
+		}
 	}
 
 	/**
@@ -497,6 +517,22 @@ var WP20MeetupEvents = app = ( function( $ ) {
 			noMatches.css( 'display', 'none' );
 			speak( strings.search_match.replace( '%s', query ) );
 		}
+	}
+
+	/**
+	 * Test if an event matches a search query.
+	 *
+	 * @param {string} eventTerms
+	 * @param {string} query
+	 *
+	 * @returns {boolean}
+	 */
+	function eventMatchesQuery( eventTerms, query ) {
+		// Sometimes `&nbsp` is used as a hack to prevent runts. If we don't replace that then a `query` of
+		// `los angeles` wouldn't match `los&nbspangeles`.
+		eventTerms = eventTerms.replace(/\u00A0/g, ' ');
+
+		return eventTerms.search( new RegExp( query, 'i' ) ) >= 0;
 	}
 
 	/**

--- a/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.js
+++ b/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.js
@@ -365,6 +365,7 @@ var WP20MeetupEvents = app = ( function( $ ) {
 				name      : events[ markerID ].name,
 				time      : events[ markerID ].time,
 				url       : events[ markerID ].eventUrl,
+				location  : events[ markerID ].location, // Custom property for `filterEventMap()`.
 
 				icon : {
 					url        : options.markerIconBaseURL + options.markerIcon,
@@ -484,6 +485,8 @@ var WP20MeetupEvents = app = ( function( $ ) {
 
 	/**
 	 * Filter the list of events based on a user's search query.
+	 *
+	 * @param {string} query
 	 */
 	function filterEventList( query ) {
 		var events = $( '.wp20-events-list' ).children( 'li' );
@@ -500,13 +503,15 @@ var WP20MeetupEvents = app = ( function( $ ) {
 
 		events.each( function( index, event ) {
 			var groupName = $( event ).children( '.wp20-event-group' ).text().trim(),
-			    location  = $( event ).data( 'location' );
+			    location  = $( event ).data( 'location' ),
+			    eventName = $( event ).data( 'name' ),
+			    haystack  = groupName + ' ' + eventName + ' ' + location;
 
-			if ( -1 === groupName.search( new RegExp( query, 'i' ) ) && -1 === location.search( new RegExp( query, 'i' ) ) ) {
+			if ( eventMatchesQuery( haystack, query ) ) {
+				$( event ).attr( 'aria-hidden', false );
+			} else {
 				$( event ).attr( 'aria-hidden', true );
 				countHidden++;
-			} else {
-				$( event ).attr( 'aria-hidden', false );
 			}
 		} );
 

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -917,13 +917,21 @@ body.page-slug-whats-on h1.entry-title {
 #wp20-events-map {
 	background-color: #AADAFF;
 	margin: 0 auto 40px;
+	min-height: 175px;
 	height: 530px;
+
+	/*
+	 * The map should be short enough that the user can view it and the search field at the same time.
+	 * `160` is the height of the search box plus all the padding/margin around it and the map.t
+	 */
+	max-height: calc( 100vh - 160px );
 }
 @media screen and ( max-width: 48em ) {
 	#wp20-events-map {
 		position: relative;
 		width: 100vw;
 		height: 490px;
+		max-height: calc( 100vh - 130px );
 		left: calc( -1 * var(--wp20--spacing--edge-space) );
 	}
 }


### PR DESCRIPTION
See https://github.com/WordPress/wp20.wordpress.net/pull/50#issuecomment-1500197581

This makes it so that markers on the map are filtered as the user types a query, similar to how they are filtered in the list.

The map and list should display the same results; e.g., `los` should return `los angeles` and `tegal` (because the description contains `glosarium`.