### PR TITLE
Clean up map code

### DIFF
--- a/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.js
+++ b/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.js
@@ -51,12 +51,29 @@ var WP20MeetupEvents = ( function( $ ) {
 			throw 'Google Maps library is not loaded.';
 		}
 
-		/*
-		 * These styles were generated from https://mapstyle.withgoogle.com/.
-		 * The following settings were used: Silver theme, roads 2, landmarks 2, labels 3.
-		 * The water color was change to #c7d1ff.
-		 */
-		var mapStyle = [
+		var map, markerCluster,
+			mapOptions = {
+				center            : new google.maps.LatLng( 15.000, 7.000 ),
+				zoom              : 2,
+				zoomControl       : true,
+				mapTypeControl    : false,
+				streetViewControl : false,
+				styles            : getMapStyles()
+		};
+
+		map           = new google.maps.Map( document.getElementById( container ), mapOptions );
+		markers       = createMarkers(  map, markers );
+		markerCluster = clusterMarkers( map, markers );
+	}
+
+	/**
+	 * Get the styles for the map.
+	 *
+	 * These were generated from https://mapstyle.withgoogle.com/ with these settings:
+	 * Theme Silver, Roads 2, Landmarks 2, Labels 3, Water color #c7d1ff.
+	 */
+	function getMapStyles() {
+		var styles = [
 			{
 				"elementType": "geometry",
 				"stylers": [
@@ -303,19 +320,7 @@ var WP20MeetupEvents = ( function( $ ) {
 			}
 		];
 
-		var map, markerCluster,
-			mapOptions = {
-				center            : new google.maps.LatLng( 15.000, 7.000 ),
-				zoom              : 2,
-				zoomControl       : true,
-				mapTypeControl    : false,
-				streetViewControl : false,
-				styles            : mapStyle
-		};
-
-		map           = new google.maps.Map( document.getElementById( container ), mapOptions );
-		markers       = createMarkers(  map, markers );
-		markerCluster = clusterMarkers( map, markers );
+		return styles;
 	}
 
 	/**

--- a/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.js
+++ b/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.js
@@ -50,9 +50,9 @@ var WP20MeetupEvents = app = ( function( $ ) {
 	 * Build a Google Map in the given container with the given marker data.
 	 *
 	 * @param {string} container
-	 * @param {object} markers
+	 * @param {object} events
 	 */
-	function loadMap( container, markers ) {
+	function loadMap( container, events ) {
 		if ( ! $( '#' + container ).length ) {
 			throw "Map container element isn't present in the DOM.";
 		}
@@ -71,7 +71,7 @@ var WP20MeetupEvents = app = ( function( $ ) {
 		};
 
 		app.map           = new google.maps.Map( document.getElementById( container ), mapOptions );
-		app.markers       = createMarkers( markers );
+		app.markers       = createMarkers( events );
 		app.markerCluster = clusterMarkers();
 	}
 
@@ -338,28 +338,29 @@ var WP20MeetupEvents = app = ( function( $ ) {
 	 * Normally the markers would be assigned to the map at this point, but we'll run them through MarkerClusterer
 	 * later on, so adding them to the map now is unnecessary and negatively affects performance.
 	 *
-	 * @param {object}          markers
+	 * @param {object}          events
 	 *
 	 * @return {object}
 	 */
-	function createMarkers( markers ) {
+	function createMarkers( events ) {
 		var markerID,
+			markers            = {},
 			infoWindowTemplate = _.template( $( '#tmpl-wp20-map-marker' ).html(), null, templateOptions ),
 			infoWindow         = new google.maps.InfoWindow( {
 				pixelOffset: new google.maps.Size( -options.markerIconAnchorXOffset, 0 )
 			} );
 
-		for ( markerID in markers ) {
-			if ( ! markers.hasOwnProperty( markerID ) ) {
+		for ( markerID in events ) {
+			if ( ! events.hasOwnProperty( markerID ) ) {
 				continue;
 			}
 
 			markers[ markerID ] = new google.maps.Marker( {
 				id        : markerID,
-				group     : markers[ markerID ].group,
-				name      : markers[ markerID ].name,
-				time      : markers[ markerID ].time,
-				url       : markers[ markerID ].eventUrl,
+				group     : events[ markerID ].group,
+				name      : events[ markerID ].name,
+				time      : events[ markerID ].time,
+				url       : events[ markerID ].eventUrl,
 
 				icon : {
 					url        : options.markerIconBaseURL + options.markerIcon,
@@ -369,8 +370,8 @@ var WP20MeetupEvents = app = ( function( $ ) {
 				},
 
 				position : new google.maps.LatLng(
-					markers[ markerID ].latitude,
-					markers[ markerID ].longitude
+					events[ markerID ].latitude,
+					events[ markerID ].longitude
 				)
 			} );
 


### PR DESCRIPTION
These are some general "housekeeping" commits from that were created as part of #54, to make the filtering work easier/better. I'm breaking them off into a separate PR since they're general in nature, and it'll make reviewing #54 easier.

- Modularize map styles for readability
- Store map/markers/markerCluster "globally" for easier access
- Rename raw markers to distinguish from `google.maps.Marker`
