### PR TITLE
Wrap search label/input when needed to avoid label runt

### DIFF
--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -893,7 +893,7 @@ body.page-slug-whats-on #primary .entry-header {
 }
 
 body.page-slug-whats-on h1.entry-title {
-	width: 639px;
+	flex-basis: 55%;
 	font-size: clamp( 20px, 2.4vw, 30px);
 	margin-right: var(--wp20--spacing--medium);
 	margin-bottom: 0;
@@ -930,27 +930,29 @@ body.page-slug-whats-on h1.entry-title {
 #wp20-events-filter {
 	position: relative;
 	display: flex;
-	flex-wrap: nowrap;
+	justify-content: flex-end;
+	flex-wrap: wrap;
+	flex-basis: 45%;
 	box-sizing: border-box;
-	min-width: 325px;
 	margin-bottom: 0;
 	padding-right: 0;
 }
 
 #wp20-events-filter label {
-	margin-right: 30px;
 	margin-bottom: 0;
 	padding: 0.7em 0; /* Must match `.wp20-events-query` (inherited from TwentySeventeen. */
 }
 
 #wp20-events-filter label span {
 	font-size: 13px;
+	white-space: nowrap;
 }
 
 #wp20-events-filter .wp20-events-query {
 	flex-shrink: 0;
-	flex-grow: 1;
+	flex-grow: 0;
 	flex-basis: 200px;
+	margin-left: 30px;
 	border-radius: 2px;
 	border-color: var(--wp20--color--grey-0);
 	font-size: 12px;
@@ -966,7 +968,7 @@ body.page-slug-whats-on h1.entry-title {
 
 #wp20-events-filter button {
 	position: absolute;
-	top: 6px;
+	bottom: 7px;
 	right: 10px;
 	width: 24px;
 	height: 24px;
@@ -982,6 +984,10 @@ body.page-slug-whats-on h1.entry-title {
 
 	#wp20-events-filter label {
 		display: none;
+	}
+
+	#wp20-events-filter .wp20-events-query {
+		margin-left: 0;
 	}
 
 	#wp20-events-query-mobile {

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -941,11 +941,11 @@ body.page-slug-whats-on h1.entry-title {
 #wp20-events-filter label {
 	margin-bottom: 0;
 	padding: 0.7em 0; /* Must match `.wp20-events-query` (inherited from TwentySeventeen. */
+	text-align: right;
 }
 
 #wp20-events-filter label span {
 	font-size: 13px;
-	white-space: nowrap;
 }
 
 #wp20-events-filter .wp20-events-query {

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -895,7 +895,6 @@ body.page-slug-whats-on #primary .entry-header {
 body.page-slug-whats-on h1.entry-title {
 	flex-basis: 55%;
 	font-size: clamp( 20px, 2.4vw, 30px);
-	margin-right: var(--wp20--spacing--medium);
 	margin-bottom: 0;
 }
 @media screen and ( max-width: 48em ) {


### PR DESCRIPTION
Fixes #56

This makes the layout more flexible, to handle cases where the search label is longer than English. `Cymraeg`, `Română`, and `Deutsch` are good examples.

I initially tried out a few ways to make the existing desktop layout work with the longer text, but didn't haven enough success. I think the fundamental fix is to make the layout adapt to the content.

The mobile and wide-desktop layouts are unaffected, but this will make the search label appear on top of the input in-between `769px` and `977px`.

![filter adapt](https://user-images.githubusercontent.com/484068/231014522-65d5054d-f512-4e32-a0c8-fef621250d25.gif)

There may be a better way to design the layout at that breakpoint, this was just my rough attempt. If you see a better way please suggest it!