### PR TITLE
Fix a11y

### DIFF
--- a/wp-content/plugins/wp20-meetup-events/views/events-list.php
+++ b/wp-content/plugins/wp20-meetup-events/views/events-list.php
@@ -12,6 +12,8 @@ defined( 'WPINC' ) || die();
 
 ?>
 
+<h2 class="screen-reader-text"><?php echo esc_html( 'Events list', 'wp20' ); ?></h2>
+
 <ul class="wp20-events-list">
 	<?php foreach ( $events as $event ) : ?>
 		<li

--- a/wp-content/plugins/wp20-meetup-events/views/events-map.php
+++ b/wp-content/plugins/wp20-meetup-events/views/events-map.php
@@ -5,6 +5,8 @@ defined( 'WPINC' ) || die();
 
 ?>
 
+<h2 class="screen-reader-text"><?php echo esc_html( 'Events map', 'wp20' ); ?></h2>
+
 <div id="wp20-events-map">
 	<div class="wp20-spinner spinner spinner-visible"></div>
 </div>

--- a/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.js
+++ b/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.js
@@ -366,6 +366,7 @@ var WP20MeetupEvents = app = ( function( $ ) {
 				time      : events[ markerID ].time,
 				url       : events[ markerID ].eventUrl,
 				location  : events[ markerID ].location, // Custom property for `filterEventMap()`.
+				title     : events[ markerID ].group,
 
 				icon : {
 					url        : options.markerIconBaseURL + options.markerIcon,

--- a/wp-content/themes/twentyseventeen-wp20/page-swag.php
+++ b/wp-content/themes/twentyseventeen-wp20/page-swag.php
@@ -22,9 +22,9 @@ use WP20\Theme;
 									<div class="downloads-item-preview">
 										<img src="<?php echo esc_attr( $item['preview_image_url'] ); ?>" alt="<?php echo esc_attr( $item['title'] ); ?>" />
 									</div>
-									<h3 class="downloads-item-header">
+									<h2 class="downloads-item-header">
 										<?php echo esc_html( $item['title'] ); ?>
-									</h3>
+									</h2>
 									<p class="downloads-item-content"><?php echo esc_html( $item['content'] ); ?></p>
 									<?php if ( ! empty( $item['files'] ) ) : ?>
 										<ul class="downloads-item-files">

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -93,7 +93,6 @@ p {
 
 h1,
 h2,
-h2.wp20-event-group,
 h3,
 .page .panel-content .entry-title,
 .page-title,
@@ -114,7 +113,7 @@ body.page:not(.twentyseventeen-front-page) .entry-title,
 @media screen and ( min-width: 769px ) {
 	h1,
 	h2,
-	h3,
+	h3:not(.wp20-event-group),
 	.page .panel-content .entry-title,
 	.page-title,
 	body.page:not(.twentyseventeen-front-page) .entry-title,
@@ -1038,7 +1037,7 @@ body.page-slug-whats-on h1.entry-title {
 	margin-right: 0;
 }
 
-h2.wp20-event-group,
+.wp20-event-group,
 .wp20-event-title {
 	margin-bottom: 6px;
 }

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -93,8 +93,8 @@ p {
 
 h1,
 h2,
+h2.wp20-event-group,
 h3,
-h3.wp20-event-group,
 .page .panel-content .entry-title,
 .page-title,
 body.page:not(.twentyseventeen-front-page) .entry-title,
@@ -1037,7 +1037,7 @@ body.page-slug-whats-on h1.entry-title {
 	margin-right: 0;
 }
 
-h3.wp20-event-group,
+h2.wp20-event-group,
 .wp20-event-title {
 	margin-bottom: 6px;
 }

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -151,6 +151,7 @@ body.page:not(.twentyseventeen-front-page) .entry-title,
 	color: var(--wp20--color--text-link);
 }
 
+.entry-content a:not(.downloads-item a):not(.post-navigation a):not(.wp20-events-list a),
 .entry-content a:focus,
 .entry-content a:hover,
 .entry-summary a:focus,


### PR DESCRIPTION
Fixes #11 

- [x] Replace H3 on Events list and Swag items with H2, to correct heading structure
- [x] Accessible names on map marker buttons
- [x] Accessible links in entry content using underline

Changing the color of the links didn't work; the issue is that the blueberry link text has insufficient contrast with the very dark grey body text, so going darker doesn't help, and going lighter (Blueberry 2 #7B90FF) results in insufficient contrast with the background.

### Screenshots

| What's on? | Single | Swag |
|-|-|-|
| ![Screen Shot 2023-04-12 at 12 41 40 PM](https://user-images.githubusercontent.com/1017872/231318631-1a0a7bbb-fa0a-4620-b589-587e6769dcd7.jpg) | ![wp20 mystagingwebsite com_wapuu-coloring-giveaway-style-your-own-party-wapuu_(Desktop)](https://user-images.githubusercontent.com/1017872/231318620-6f68a96b-90c4-46ee-9132-7084e8133616.png) | ![wp20 mystagingwebsite com_swag_(Desktop)](https://user-images.githubusercontent.com/1017872/231318612-4136b466-3a55-4724-82c4-b8e03de8f876.png) |