### PR TITLE
Make block button margins consistent with paragraphs

### DIFF
--- a/wp-content/themes/twentyseventeen-wp20/functions.php
+++ b/wp-content/themes/twentyseventeen-wp20/functions.php
@@ -5,7 +5,7 @@ namespace WP20\Theme;
 defined( 'WPINC' ) || die();
 
 add_filter( 'template_include',      __NAMESPACE__ . '\get_front_page_template'          );
-add_action( 'wp_enqueue_scripts',    __NAMESPACE__ . '\enqueue_scripts'                  );
+add_action( 'wp_enqueue_scripts',    __NAMESPACE__ . '\enqueue_scripts', 11              );
 add_filter( 'get_custom_logo',       __NAMESPACE__ . '\set_custom_logo'                  );
 add_filter( 'body_class',            __NAMESPACE__ . '\add_body_classes'                 );
 add_filter( 'the_title',             __NAMESPACE__ . '\internationalize_titles'          );
@@ -97,15 +97,22 @@ function enqueue_scripts() {
 		get_fonts_url()
 	);
 
-	wp_register_style(
-		'twentyseventeen-parent-style',
-		get_template_directory_uri() . '/style.css'
-	);
+	// TwentySeventeen enqueues the child theme instead of itself, which makes things like
+	// `twentyseventeen-block-style` load _after_ `twentyseventeen-wp20-style`. That makes it difficult to
+	// override parent theme styles. We need to reregister it so the parent theme styles load first.
+	wp_deregister_style( 'twentyseventeen-style' );
 
 	wp_enqueue_style(
 		'twentyseventeen-style',
+		get_template_directory_uri() . '/style.css',
+		array(),
+		filemtime( get_template_directory() . '/style.css' )
+	);
+
+	wp_enqueue_style(
+		'twentyseventeen-wp20-style',
 		get_stylesheet_directory_uri() . '/style.css',
-		array( 'twentyseventeen-parent-style', 'twentyseventeen-wp20-fonts', 'dashicons' ),
+		array( 'twentyseventeen-style', 'twentyseventeen-wp20-fonts', 'dashicons' ),
 		filemtime( __DIR__ . '/style.css' )
 	);
 

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -81,6 +81,14 @@ p {
 	margin-bottom: var(--wp20--spacing--small);
 }
 
+.wp-block-buttons {
+	margin-bottom: var(--wp20--spacing--small);
+}
+
+.wp-block-button .wp-block-button__link {
+	margin-top: 0;
+}
+
 @media screen and ( min-width: 769px ) {
 	body {
 		font-size: 14px;

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -81,18 +81,22 @@ p {
 	margin-bottom: var(--wp20--spacing--small);
 }
 
+@media screen and ( min-width: 769px ) {
+	body {
+		font-size: 14px;
+	}
+}
+
+/* 
+ * Blocks
+ */
+
 .wp-block-buttons {
 	margin-bottom: var(--wp20--spacing--small);
 }
 
 .wp-block-button .wp-block-button__link {
 	margin-top: 0;
-}
-
-@media screen and ( min-width: 769px ) {
-	body {
-		font-size: 14px;
-	}
 }
 
 /*

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -158,7 +158,7 @@ body.page:not(.twentyseventeen-front-page) .entry-title,
 	color: var(--wp20--color--text-link);
 }
 
-.entry-content a:not(.downloads-item a):not(.post-navigation a):not(.wp20-events-list a),
+.entry-content a:not(.downloads-item a):not(.post-navigation a):not(.wp20-events-list a):not(.wp-block-button__link),
 .entry-content a:focus,
 .entry-content a:hover,
 .entry-summary a:focus,


### PR DESCRIPTION
See #76

This fixes the margins for the Spotify button on https://wp20.mystagingwebsite.com/20-years-of-wordpress-jazz/. The colors may need to be manually fixed after launch, since they're set in the editor.

This has some added potential for unintended side effects, because now `twentyseventeen/assets/css/blocks.css` is loading _before_ `twentyseventeen-wp20/style.css`, but I haven't spotted any in testing. The `20 Years` post is the only one that uses the Button block so far.