### PR TITLE
Increase `font-size` of download links

### DIFF
--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -1528,7 +1528,6 @@ body.page-slug-whats-on h1.entry-title {
 }
 
 .downloads-wrapper .downloads-item-files {
-	font-size: 12px;
 	margin: 0;
 }
 


### PR DESCRIPTION
Fixes #67

I didn't see a good way to remove the typographic rivers, but we can iterate if anyone sees one. IMO that's just the nature of the web, though.
