### PR TITLE
Compare timestamps when sorting to preserve natural ordering

### DIFF
--- a/wp-content/plugins/wp20-meetup-events/views/events-list.php
+++ b/wp-content/plugins/wp20-meetup-events/views/events-list.php
@@ -12,7 +12,7 @@ defined( 'WPINC' ) || die();
 
 ?>
 
-<h2 class="screen-reader-text"><?php echo esc_html( 'Events list', 'wp20' ); ?></h2>
+<h2 class="screen-reader-text"><?php esc_html_e( 'Events list', 'wp20' ); ?></h2>
 
 <ul class="wp20-events-list">
 	<?php foreach ( $events as $event ) : ?>

--- a/wp-content/plugins/wp20-meetup-events/views/events-map.php
+++ b/wp-content/plugins/wp20-meetup-events/views/events-map.php
@@ -5,7 +5,7 @@ defined( 'WPINC' ) || die();
 
 ?>
 
-<h2 class="screen-reader-text"><?php echo esc_html( 'Events map', 'wp20' ); ?></h2>
+<h2 class="screen-reader-text"><?php esc_html_e( 'Events map', 'wp20' ); ?></h2>
 
 <div id="wp20-events-map">
 	<div class="wp20-spinner spinner spinner-visible"></div>

--- a/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.php
+++ b/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.php
@@ -258,11 +258,14 @@ function get_formatted_events() : array {
  * Sort events by their timestamp.
  */
 function sort_events( array $a, array $b ) : int {
-	if ( $a['time'] === $b['time'] ) {
+	$a_timestamp = strtotime( $a['time'] );
+	$b_timestamp = strtotime( $b['time'] );
+
+	if ( $a_timestamp === $b_timestamp ) {
 		return 0;
 	}
 
-	return $a['time'] > $b['time'] ? 1 : - 1;
+	return $a_timestamp > $b_timestamp ? 1 : - 1;
 }
 
 /**

--- a/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.php
+++ b/wp-content/plugins/wp20-meetup-events/wp20-meetup-events.php
@@ -269,8 +269,6 @@ function sort_events( array $a, array $b ) : int {
  * Render the WP20 events map shortcode.
  */
 function render_events_map_shortcode() : string {
-	$events = get_formatted_events();
-
 	ob_start();
 	require_once( __DIR__ . '/views/events-map.php' );
 	return ob_get_clean();
@@ -292,8 +290,6 @@ function render_events_list_shortcode() : string {
  * Render the WP20 events filter shortcode.
  */
 function render_events_filter_shortcode() : string {
-	$events = get_formatted_events();
-
 	ob_start();
 	require_once( __DIR__ . '/views/events-filter.php' );
 	return ob_get_clean();


### PR DESCRIPTION
Fixes #79

`Jena` now correctly shows up at the top:

<img width="1215" alt="Screenshot 2023-04-17 at 4 23 59 PM" src="https://user-images.githubusercontent.com/484068/232631645-9461cb99-6de3-41e5-b2ad-4ef8c4c21c8c.png">

I've deployed this to the staging site to make testing easier.

The main fix here is to the sorting, but these additional minor tweaks were made:

- Fix broken localization
- Remove unused variables
