### PR TITLE
Update page titles

### DIFF
--- a/wp-content/themes/twentyseventeen-wp20/functions.php
+++ b/wp-content/themes/twentyseventeen-wp20/functions.php
@@ -189,26 +189,24 @@ function internationalize_titles( $title ) {
 			$title = esc_html__( 'WordPress turns 20 on May 27, 2023', 'wp20' );
 			break;
 
-		case "What's On":
-		case "What’s On":
-		case 'What&#8217;s On':
-			// translators: The name of the page that lists the global WP20 meetup events. "What's on" means something similar to "what's going on" or "what's happening".
-			$title = esc_html__( "What's On", 'wp20' );
+		case "Events":
+			// translators: The name of the page that lists the global WP20 meetup events.
+			$title = esc_html__( "Events", 'wp20' );
 			break;
 
-		case 'News':
+		case 'Things to Do':
 			// translators: The name of the page that list recent posts.
-			$title = esc_html__( 'News', 'wp20' );
+			$title = esc_html__( 'Things to Do', 'wp20' );
 			break;
 
-		case '#WP Live':
+		case '#WP20 Live':
 			// translators: The name of the page that displays the #wp20 social media posts in real time.
-			$title = esc_html_x( '#WP Live', 'adjective', 'wp20' );
+			$title = esc_html_x( '#WP20 Live', 'adjective', 'wp20' );
 			break;
 
-		case 'Swag':
-			// translators: "Swag" is a term for promotional items. This is the title of the page.
-			$title = esc_html__( 'Swag', 'wp20' );
+		case 'Merchandise':
+			// translators: "Merchandise" is a term for promotional items. This is the text for a navigation link to mercantile.wordpress.org.
+			$title = esc_html__( 'Merchandise', 'wp20' );
 			break;
 
 		case 'Celebrating 20 years of WordPress':

--- a/wp-content/themes/twentyseventeen-wp20/template-parts/header/navigation-top.php
+++ b/wp-content/themes/twentyseventeen-wp20/template-parts/header/navigation-top.php
@@ -6,7 +6,7 @@
 $title = get_the_title();
 
 if ( is_single() || is_archive() ) {
-	$title = __( 'News', 'wp20' );
+	$title = __( 'Things to Do', 'wp20' );
 } elseif ( is_404() ) {
 	$title = __( 'Page not found', 'wp20' );
 }


### PR DESCRIPTION
Fixes #90 

The page titles have been updated on production so the i18n needs to be updated too.

What's on? -> Events
News -> Things to Do
#WP Live -> #WP20 Live
Swag -> Merchandise

There is conditional logic for the mobile navigation that needed to be updated too.