### PR TITLE
Update WP15 nostalgia link to wp15.wordpress.net

### DIFF
--- a/wp-content/themes/twentyseventeen-wp20/footer.php
+++ b/wp-content/themes/twentyseventeen-wp20/footer.php
@@ -21,8 +21,8 @@
 
 					<p class="wp20-nostalgia">
 						<?php printf(
-							wp_kses_post( __( '<strong>Feeling nostalgic?</strong><br> Check out <a href="%s">this post about the WordPress 15th anniversary</a>.', 'wp20' ) ),
-							'https://wordpress.org/news/2018/04/celebrate-the-wordpress-15th-anniversary-on-may-27/'
+							wp_kses_post( __( '<strong>Feeling nostalgic?</strong><br> Check out <a href="%s">this website about the WordPress 15th anniversary</a>.', 'wp20' ) ),
+							'https://wp15.wordpress.net'
 						); ?>
 					</p>
 


### PR DESCRIPTION
Fixes #88 

Change the nostalgia link in the footer to the WP15.wordpress.net site, as it's a more comprehensive look at prior celebrations/events/etc.

![Screen Shot 2023-05-04 at 4 11 15 PM](https://user-images.githubusercontent.com/1017872/236111170-746ef44e-26dc-4bf4-b442-5c7d30eb8091.jpg)
