### PR TITLE
Update header copy on events page

### DIFF
--- a/wp-content/plugins/wp20-meetup-events/views/events-map.php
+++ b/wp-content/plugins/wp20-meetup-events/views/events-map.php
@@ -5,8 +5,6 @@ defined( 'WPINC' ) || die();
 
 ?>
 
-<h2 class="screen-reader-text"><?php esc_html_e( 'Events map', 'wp20' ); ?></h2>
-
 <div id="wp20-events-map">
 	<div class="wp20-spinner spinner spinner-visible"></div>
 </div>

--- a/wp-content/themes/twentyseventeen-wp20/page-whats-on.php
+++ b/wp-content/themes/twentyseventeen-wp20/page-whats-on.php
@@ -6,13 +6,18 @@
 			<article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 
 				<header class="entry-header">
-					<h1 class="entry-title">
-						<?php printf(
-							wp_kses_post( __( 'People all over the world are celebrating the WordPress 20th Anniversary on May 27, 2023.<br><br>Below are listed all of the <a href="%s">WordPress Chapter meetups</a> that are hosting events. Don’t see one in your area? <a href="%s">Apply to start one today!</a>', 'wp20' ) ),
-								'https://make.wordpress.org/community/handbook/meetup-organizer/meetup-program-basics/',
-								'https://make.wordpress.org/community/handbook/meetup-organizer/getting-started/interest-form/'
-						); ?>
-					</h1>
+					<div class="wp20-events-header">
+						<h1 class="entry-title">
+							<?php esc_html_e( 'People all over the world are celebrating the WordPress 20th Anniversary on May 27, 2023.', 'wp20' ); ?>
+						</h1>
+						<h2>
+							<?php printf(
+								wp_kses_post( __( 'Below are listed all of the <a href="%s">WordPress Chapter meetups</a> that are hosting events. Don’t see one in your area? <a href="%s">Apply to start one today!</a>', 'wp20' ) ),
+									'https://make.wordpress.org/community/handbook/meetup-organizer/meetup-program-basics/',
+									'https://make.wordpress.org/community/handbook/meetup-organizer/getting-started/interest-form/'
+							); ?>
+						</h2>
+					</div>
 
 					<?php echo do_shortcode( '[wp20_meetup_events_filter]' ); ?>
 				</header>

--- a/wp-content/themes/twentyseventeen-wp20/page-whats-on.php
+++ b/wp-content/themes/twentyseventeen-wp20/page-whats-on.php
@@ -7,7 +7,11 @@
 
 				<header class="entry-header">
 					<h1 class="entry-title">
-						<?php esc_html_e( 'People all over the world are celebrating the WordPress 20th Anniversary on May 27, 2023. Join the meetups throughout the whole year!', 'wp20' ); ?>
+						<?php printf(
+							wp_kses_post( __( 'People all over the world are celebrating the WordPress 20th Anniversary on May 27, 2023.<br><br>Below are listed all of the <a href="%s">WordPress Chapter meetups</a> that are hosting events. Don’t see one in your area? <a href="%s">Apply to start one today!</a>', 'wp20' ) ),
+								'https://make.wordpress.org/community/handbook/meetup-organizer/meetup-program-basics/',
+								'https://make.wordpress.org/community/handbook/meetup-organizer/getting-started/interest-form/'
+						); ?>
 					</h1>
 
 					<?php echo do_shortcode( '[wp20_meetup_events_filter]' ); ?>

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -140,7 +140,6 @@ body.page:not(.twentyseventeen-front-page) .entry-title,
  * Links
  */
 
-.page-slug-whats-on .entry-header a,
 .entry-meta a,
 .page-links a,
 .page-links a .page-number,
@@ -916,8 +915,12 @@ body.page-slug-whats-on #primary .entry-header {
 	margin-bottom: var(--wp20--spacing--small);
 }
 
-body.page-slug-whats-on .entry-title {
+.wp20-events-header {
 	flex-basis: 55%;
+}
+
+body.page-slug-whats-on .entry-title,
+body.page-slug-whats-on .entry-header h2 {
 	font-size: clamp( 20px, 2.4vw, 30px);
 }
 
@@ -929,7 +932,7 @@ body.page-slug-whats-on .entry-title {
 		margin-bottom: var(--wp20--spacing--xxsmall);
 	}
 
-	body.page-slug-whats-on .entry-title {
+	body.page-slug-whats-on .entry-header h2 {
 		margin-bottom: 0;
 	}
 }

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -140,6 +140,7 @@ body.page:not(.twentyseventeen-front-page) .entry-title,
  * Links
  */
 
+.page-slug-whats-on .entry-header a,
 .entry-meta a,
 .page-links a,
 .page-links a .page-number,
@@ -912,27 +913,24 @@ span + .autocomplete__input.autocomplete__input--focused {
  */
 
 body.page-slug-whats-on #primary .entry-header {
-	display: flex;
-	justify-content: space-between;
-	align-items: flex-end;
+	margin-bottom: var(--wp20--spacing--small);
 }
 
-@media screen and ( max-width: 48em ) {
-	body.page-slug-whats-on #primary .entry-header {
-		display: block;
-		margin-bottom: var(--wp20--spacing--small);
-	}
-}
-
-body.page-slug-whats-on h1.entry-title {
+body.page-slug-whats-on .entry-title {
 	flex-basis: 55%;
 	font-size: clamp( 20px, 2.4vw, 30px);
-	margin-bottom: 0;
 }
-@media screen and ( max-width: 48em ) {
-	body.page-slug-whats-on h1.entry-title {
-		width: auto;
-		margin-bottom: var(--wp20--spacing--small);
+
+@media screen and ( min-width: 769px ) {
+	body.page-slug-whats-on #primary .entry-header {
+		display: flex;
+		justify-content: space-between;
+		align-items: flex-end;
+		margin-bottom: var(--wp20--spacing--xxsmall);
+	}
+
+	body.page-slug-whats-on .entry-title {
+		margin-bottom: 0;
 	}
 }
 


### PR DESCRIPTION
Closes #97 

This PR adds some language to the events (home) page that states that the tracker only shows events planned by meetups who are part of the Chapter Program, and an invitation to apply to join if they're not in the program.

This text replaces the previously screen reader only H2 for the map, as it serves as a meaningful description for that.

### Screenshots

| Desktop | Tablet | Mobile |
|-|-|-|
| ![Screen Shot 2023-05-16 at 4 25 51 PM](https://github.com/WordPress/wp20.wordpress.net/assets/1017872/8f7b6aa3-727e-4091-9fbb-61973a0b1b43) | ![wp20 mystagingwebsite com__locale=en_NZ(iPad)](https://github.com/WordPress/wp20.wordpress.net/assets/1017872/8ca95b76-a5b7-4cc8-8cfb-b483c64979da) | ![wp20 mystagingwebsite com__locale=en_NZ(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/wp20.wordpress.net/assets/1017872/e07d3a45-dd40-4bda-ba67-19d30b015c91) |