### PR TITLE
Fix header layout issues on small screens

### DIFF
--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -523,11 +523,17 @@ body:not(.title-tagline-hidden) .site-branding-text {
 	}
 }
 
-@media screen and (min-width: 769px) {
+@media screen and (min-width: 48em) {
 	.navigation-top {
 		position: unset;
 	}
 
+	.navigation-top .wrap {
+		padding: 0;
+	}
+}
+
+@media screen and (min-width: 769px) {
 	.navigation-top .wrap {
 		padding: 0 var(--wp20--spacing--edge-space);
 	}

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -760,6 +760,8 @@ input.autocomplete__input,
 	line-height: 26px;
 	border-radius: 0;
 	background: transparent;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 input.autocomplete__input::placeholder {


### PR DESCRIPTION
Fixes #101 

The addition of the accessible locale switcher caused a regression on screens exactly 768px wide (typical iPad), due to the way breakpoints are implemented in twentyseventeen. This PR adjusts the overrides and desktop styles around that breakpoint, so that:

- The 'WordPress celebrates twenty years' text is visible
- The correct padding is applied around the nav bar items
- The nav and locale dropdowns look correct when active	

I also noticed that we hadn't handled overflow for long locale names in the switcher, so I've also added `text-overflow: ellipsis` for that.

### How to test

- Check the layout at a range of screen sizes (desktop, tablet and mobile) for regressions. In particular check screen widths at 767px and 768px (both should use mobile layout), 769px (desktop layout).
- Active the nav and locale switcher and check layout

### Screenshots

See #101 for before

| Tablet (768px ) default | Nav active | Locale switcher active |
|-|-|-|
| ![localhost_8888_(iPad) (2)](https://github.com/WordPress/wp20.wordpress.net/assets/1017872/f74c6934-8dac-4395-b8b3-c542a3d628ff) | ![localhost_8888_(iPad) (3)](https://github.com/WordPress/wp20.wordpress.net/assets/1017872/9bf3fbc3-ba44-4f9d-bb4d-eb397f7ed80a) | ![localhost_8888_(iPad) (4)](https://github.com/WordPress/wp20.wordpress.net/assets/1017872/8d25b59a-e74c-4971-94fc-a98a36394089) |

| Desktop | Mobile | Mobile small |
|-|-|-|
| ![localhost_8888__locale=en_NZ(Desktop)](https://github.com/WordPress/wp20.wordpress.net/assets/1017872/0390e8d1-4555-4494-988f-4f1f55548485) | ![localhost_8888__locale=en_NZ(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/wp20.wordpress.net/assets/1017872/2c1d3c88-61ce-4ab0-aaff-07d6e822bb1d) | ![localhost_8888_(Galaxy S5)](https://github.com/WordPress/wp20.wordpress.net/assets/1017872/e4668854-ccfb-42cd-8590-34bdb7bac6aa) |