### PR TITLE
Fix homepage heading style

### DIFF
--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -52,9 +52,11 @@ button,
 input,
 select,
 textarea,
-input::placeholder {
+input::placeholder,
+.wp20-events-header h2 {
 	font-family: 'Inter', sans-serif;
 	font-size: 13px;
+	font-weight: 400;
 	line-height: 1.4;
 	color: var(--wp20--color--text);
 	-webkit-font-smoothing: antialiased;
@@ -82,7 +84,8 @@ p {
 }
 
 @media screen and ( min-width: 769px ) {
-	body {
+	body,
+	.wp20-events-header h2 {
 		font-size: 14px;
 	}
 }
@@ -927,8 +930,7 @@ body.page-slug-whats-on #primary .entry-header {
 	flex-basis: 55%;
 }
 
-body.page-slug-whats-on .entry-title,
-body.page-slug-whats-on .entry-header h2 {
+body.page-slug-whats-on .entry-title {
 	font-size: clamp( 20px, 2.4vw, 30px);
 }
 

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -932,6 +932,7 @@ body.page-slug-whats-on #primary .entry-header {
 
 body.page-slug-whats-on .entry-title {
 	font-size: clamp( 20px, 2.4vw, 30px);
+	margin-bottom: var(--wp20--spacing--xxsmall);
 }
 
 @media screen and ( min-width: 769px ) {
@@ -939,7 +940,11 @@ body.page-slug-whats-on .entry-title {
 		display: flex;
 		justify-content: space-between;
 		align-items: flex-end;
-		margin-bottom: var(--wp20--spacing--xxsmall);
+		margin-bottom: var(--wp20--spacing--xsmall);
+	}
+
+	body.page-slug-whats-on .entry-title {
+		margin-bottom: var(--wp20--spacing--xsmall);
 	}
 
 	body.page-slug-whats-on .entry-header h2 {

--- a/wp-content/themes/twentyseventeen-wp20/template-parts/header/site-branding.php
+++ b/wp-content/themes/twentyseventeen-wp20/template-parts/header/site-branding.php
@@ -13,7 +13,7 @@ use WP20\Theme;
 	<?php if ( is_front_page() ): ?>
 	<div class="site-branding-text">
 		<em>
-			<?php echo esc_html( Theme\prevent_widows_in_content( __( 'WordPress celebrates twenty years', 'twentyseventeen' ) ) ) ?>
+			<?php echo esc_html( Theme\prevent_widows_in_content( __( 'WordPress celebrates twenty years', 'wp20' ) ) ) ?>
 		</em>
 	</div><!-- .site-branding-text -->
 	<?php endif; ?>


### PR DESCRIPTION
Fixes #103 

There are 2 headings on the homepage, with the same style, introduced in https://github.com/WordPress/wp20.wordpress.net/pull/98

This PR restyles the h2 to resemble the body font.

It also fixes a text domain issue related to the site branding copy.

### Screenshots

| Desktop | Tablet | Mobile |
|-|-|-|
| ![wp20 mystagingwebsite com_(Desktop)](https://github.com/WordPress/wp20.wordpress.net/assets/1017872/aacd1dcb-5e48-4321-a288-956a2d136213) | ![wp20 mystagingwebsite com_(iPad)](https://github.com/WordPress/wp20.wordpress.net/assets/1017872/75f0482d-a9aa-4efd-bf25-301590179532) | ![wp20 mystagingwebsite com_(Samsung Galaxy S20 Ultra)](https://github.com/WordPress/wp20.wordpress.net/assets/1017872/e1e7a2e7-2477-41a9-8be2-549a9b10125d) |