### PR TITLE
Add EB Garamond Italic font

### DIFF
--- a/wp-content/themes/twentyseventeen-wp20/functions.php
+++ b/wp-content/themes/twentyseventeen-wp20/functions.php
@@ -80,6 +80,14 @@ function get_fonts_url() {
 		$fonts[] = 'EB Garamond:400';
 	}
 
+	/*
+	 * Translators: If there are characters in your language that are not supported
+	 * by EB Garamond Italic, translate this to 'off'. Do not translate into your own language.
+	 */
+	if ( 'off' !== _x( 'on', 'EB Garamond Italic font: on or off', 'wp20' ) ) {
+		$fonts[] = 'EB Garamond:ital';
+	}
+
 	if ( $fonts ) {
 		$fonts_url = add_query_arg( array(
 			'family' => rawurlencode( implode( '|', $fonts ) ),


### PR DESCRIPTION
Fixes #106 

EB Garamond Italic is missing from our Google fonts. It's used in one place, for the site branding text below the logo.

Before:
![wp20 wordpress net__locale=en_NZ(Desktop)](https://github.com/WordPress/wp20.wordpress.net/assets/1017872/ed91272f-b3fd-4e59-b538-8e3fceafc12a)

After:
![wp20 mystagingwebsite com__locale=en_NZ(Desktop)](https://github.com/WordPress/wp20.wordpress.net/assets/1017872/99f1fac6-f474-4fea-8f27-5ad0132394e6)
