### PR TITLE
Add announcement banner with WCEU keynote

### DIFF
--- a/wp-content/themes/twentyseventeen-wp20/header.php
+++ b/wp-content/themes/twentyseventeen-wp20/header.php
@@ -35,5 +35,11 @@ use WP20\Locales;
 
 		<?php Locales\locale_notice(); ?>
 
+		<?php
+		if ( is_front_page() ) {
+			get_template_part( 'template-parts/announcement-banner' );
+		}
+		?>
+
 		<div class="site-content-contain">
 			<div id="content" class="site-content">

--- a/wp-content/themes/twentyseventeen-wp20/style.css
+++ b/wp-content/themes/twentyseventeen-wp20/style.css
@@ -911,6 +911,87 @@ span + .autocomplete__input.autocomplete__input--focused {
 	color: var(--wp20--color--primary);
 }
 
+
+/*
+ * Announcement Banner
+ */
+
+.announcement-banner {
+	/*
+	 * Grid is a little overkill for the mobile layout, but it's necessary to set the `order` on the video.
+	 * That's necessary for semantics and accessibility. Grid is useful for the desktop layout, so there's
+	 * also a benefit to them sharing styles.
+	 */
+	display: grid;
+	grid-template-rows: auto auto auto auto;
+	grid-template-columns: 100%;
+	grid-template-areas:
+		"video"
+		"heading"
+		"text"
+		"meta-social";
+	gap: var(--wp20--spacing--xxsmall);
+	width: 100%;
+	padding-top: var(--wp20--spacing--small);
+	padding-bottom: var(--wp20--spacing--small);
+	border-bottom: 1px solid var(--wp20--color--border);
+}
+
+.announcement-banner > * {
+	margin: 0; /* Grid `gap` will handle spacing. */
+}
+
+.announcement-banner h2 {
+	grid-area: heading;
+	order: 2;
+}
+
+.announcement-banner .announcement-video {
+	grid-area: video;
+	order: 1;
+}
+
+.announcement-banner p {
+	font-size: 14px;
+	line-height: 21px;
+}
+
+.announcement-banner a {
+	color: var(--wp20--color--text);
+	text-decoration-line: underline;
+}
+
+.announcement-banner p.announcement-text {
+	grid-area: text;
+	order: 3;
+	padding-bottom: var(--wp20--spacing--xsmall);
+}
+
+.announcement-banner p.announcement-meta-social {
+	grid-area: meta-social;
+	order: 4;
+	display: flex;
+	justify-content: space-between;
+	align-items: flex-start;
+	gap: var(--wp20--spacing--medium);
+	max-width: 315px;
+}
+
+@media screen and ( min-width: 900px ) {
+	.announcement-banner {
+		grid-template-rows: auto auto auto;
+		grid-template-columns: 357px 340px;
+		grid-template-areas:
+			"video heading"
+			"video text"
+			"video meta-social";
+		gap:  var(--wp20--spacing--medium);
+		padding-top: var(--wp20--spacing--medium);
+		padding-bottom: var(--wp20--spacing--medium);
+	}
+}
+
+
 /*
  * All content
  */

--- a/wp-content/themes/twentyseventeen-wp20/template-parts/announcement-banner.php
+++ b/wp-content/themes/twentyseventeen-wp20/template-parts/announcement-banner.php
@@ -1,0 +1,30 @@
+<section class="announcement-banner wrap wrap-wide">
+	<h2>WCEU 2023 Keynote</h2>
+
+	<figure class="announcement-video wp-block-embed is-type-video is-provider-youtube wp-block-embed-youtube wp-embed-aspect-16-9 wp-has-aspect-ratio">
+		<div class="wp-block-embed__wrapper">
+			<iframe
+				title="WordCamp Europe 2023 Keynote"
+				width="740"
+				height="416"
+				src="https://www.youtube.com/embed/7Nmz3IjtPh0?feature=oembed"
+				frameborder="0"
+				allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+				allowfullscreen>
+			</iframe>
+		</div>
+	</figure>
+
+	<p class="announcement-text">
+		<a href="https://www.youtube.com/watch?v=7Nmz3IjtPh0">
+			Watch the recording of the 2023 WordCamp Europe keynote
+		</a>
+		reflecting on 20 years of WordPress and democratizing publishing.
+	</p>
+
+	<p class="announcement-meta-social">
+		<span>Date: Jun 10th 2023</span>
+		<span>#WCEU</span>
+		<span>#WP20</span>
+	</p>
+</section>


### PR DESCRIPTION
This adds the WCEU keynote video in a new banner on the front page.

I'm going to go ahead and merge, then deploy to staging for design review. We can iterate from there in a subsequent PR.